### PR TITLE
Fix SQL escaping in database schema name

### DIFF
--- a/src/main/java/com/gmail/trentech/pjc/core/SQLManager.java
+++ b/src/main/java/com/gmail/trentech/pjc/core/SQLManager.java
@@ -84,11 +84,14 @@ public class SQLManager {
 
 		if (mySql) {
 			Connection connection = sqlService.getDataSource("jdbc:mysql://" + url + "/?user=" + username + "&password=" + password).getConnection();
+			PreparedStatement statement = connection.prepareStatement("CREATE DATABASE IF NOT EXISTS `" + database + "`");
 
-			PreparedStatement statement = connection.prepareStatement("CREATE DATABASE IF NOT EXISTS " + database);
-			statement.executeUpdate();
-			statement.close();
-			connection.close();
+			try {
+				statement.executeUpdate();
+			} finally {
+				statement.close();
+				connection.close();
+			}
 
 			return sqlService.getDataSource("jdbc:mysql://" + url + "/" + database + "?user=" + username + "&password=" + password);
 		} else {


### PR DESCRIPTION
- Escape database schema name with backticks to avoid issues with special characters, e.g. hyphens
- Wrap DB creation command in try/finally so the connection doesn't get leaked in the event of an error

(fixes #2)